### PR TITLE
chore: remove redundant code

### DIFF
--- a/src/frontend/go.mod
+++ b/src/frontend/go.mod
@@ -11,7 +11,6 @@ require (
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0
 	go.opentelemetry.io/otel/sdk v1.42.0
-	go.opentelemetry.io/otel/trace v1.42.0
 	google.golang.org/grpc v1.79.2
 	google.golang.org/protobuf v1.36.11
 )
@@ -31,6 +30,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0 // indirect
 	go.opentelemetry.io/otel/metric v1.42.0 // indirect
+	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect

--- a/src/frontend/handlers.go
+++ b/src/frontend/handlers.go
@@ -19,8 +19,6 @@ import (
 	money "github.com/kznLeaf/curated-store/src/frontend/money"
 	validator "github.com/kznLeaf/curated-store/src/frontend/validator"
 	"github.com/sirupsen/logrus"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 )
 
 var (
@@ -46,31 +44,21 @@ type ctxKeySessionID struct{}
 type ctxKeyRequestID struct{}
 
 func (fe *frontendServer) homeHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
-
-	ctx, span := tracer.Start(r.Context(), "homeHandler")
-	defer span.End()
 
 	log.WithField("[homehandler]currency", currentCurrency(r)).Info("home")
 
-	getCurrencysCtx, getCurrenciesSpan := tracer.Start(ctx, "GetCurrencies")
-	currencies, err := fe.getCurrencies(getCurrencysCtx)
-	getCurrenciesSpan.End()
+	currencies, err := fe.getCurrencies(ctx)
 	if err != nil {
 		log.Infof("could not retrieve currencies: %v", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		renderHTTPError(log, r, w, errors.New("could not retrieve currencies"), http.StatusInternalServerError)
 		return
 	}
 
-	getProductsCtx, getProductsSpan := tracer.Start(ctx, "GetProducts")
-	products, err := fe.GetProducts(getProductsCtx)
-	getProductsSpan.End()
+	products, err := fe.GetProducts(ctx)
 	if err != nil {
 		log.Infof("could not retrieve products: %v", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		renderHTTPError(log, r, w, errors.New("could not retrieve products"), http.StatusInternalServerError)
 		return
 	}
@@ -81,25 +69,17 @@ func (fe *frontendServer) homeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	ps := make([]productView, len(products))
 	for i, p := range products {
-		convertCtx, convertSpan := tracer.Start(ctx, "ConvertCurrency")
-		price, err := fe.convertCurrency(convertCtx, p.GetPriceUsd(), currentCurrency(r))
-		convertSpan.End()
+		price, err := fe.convertCurrency(ctx, p.GetPriceUsd(), currentCurrency(r))
 		if err != nil {
 			log.Infof("could not convert currency: %v", err)
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "failed to complete the order")
 			renderHTTPError(log, r, w, errors.New("could not convert currency"), http.StatusInternalServerError)
 			return
 		}
 		ps[i] = productView{p, price}
 	}
 
-	getCartCtx, getCartSpan := tracer.Start(ctx, "GetCart")
-	cart, err := fe.getCart(getCartCtx, sessionID(r))
-	getCartSpan.End()
+	cart, err := fe.getCart(ctx, sessionID(r))
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		renderHTTPError(log, r, w, errors.New("could not retrieve cart"), http.StatusInternalServerError)
 		return
 	}
@@ -171,9 +151,7 @@ func (plat *platformDetails) setPlatformDetails(env string) {
 
 func (fe *frontendServer) productHandler(w http.ResponseWriter, r *http.Request) {
 	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
-
-	ctx, span := tracer.Start(r.Context(), "productHandler")
-	defer span.End()
+	ctx := r.Context()
 
 	id := mux.Vars(r)["id"]
 	if id == "" {
@@ -183,47 +161,30 @@ func (fe *frontendServer) productHandler(w http.ResponseWriter, r *http.Request)
 	// 添加调试日志
 	log.WithField("id", id).WithField("currency", currentCurrency(r)).Debug("[producthandler]debug info:")
 
-	// 每个下游调用都需要自己的span
-	getCtx, getSpan := tracer.Start(ctx, "GetProduct")
-	product, err := fe.GetProduct(getCtx, id)
-	getSpan.End()
+	product, err := fe.GetProduct(ctx, id)
 	if err != nil {
 		log.Infof("could not retrieve product: %v", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		renderHTTPError(log, r, w, errors.New("could not retrieve product"), http.StatusInternalServerError)
 		return
 	}
 
-	currencyCtx, currencySpan := tracer.Start(ctx, "GetCurrencies")
-	currencies, err := fe.getCurrencies(currencyCtx)
-	currencySpan.End()
+	currencies, err := fe.getCurrencies(ctx)
 	if err != nil {
 		log.Infof("could not retrieve currencies: %v", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		renderHTTPError(log, r, w, errors.New("could not retrieve currencies"), http.StatusInternalServerError)
 		return
 	}
 
-	convertCurrencyCtx, convertCurrencySpan := tracer.Start(ctx, "ConvertCurrency")
-	price, err := fe.convertCurrency(convertCurrencyCtx, product.GetPriceUsd(), currentCurrency(r))
-	convertCurrencySpan.End()
+	price, err := fe.convertCurrency(ctx, product.GetPriceUsd(), currentCurrency(r))
 	if err != nil {
 		log.Infof("could not convert currency: %v", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		renderHTTPError(log, r, w, errors.New("could not convert currency"), http.StatusInternalServerError)
 		return
 	}
 
-	getRecommendationsCtx, getRecommendationsSpan := tracer.Start(ctx, "GetRecommendations")
-	recommendations, err := fe.getRecommendations(getRecommendationsCtx, sessionID(r), nil) // TODO 第三个参数为nil,也就是随机从所有产品中抽取
-	getRecommendationsSpan.End()
+	recommendations, err := fe.getRecommendations(ctx, sessionID(r), nil) // TODO 第三个参数为nil,也就是随机从所有产品中抽取
 	if err != nil {
 		log.Infof("could not retrieve recommendations: %v", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, fmt.Sprintf("could not retrieve recommendations: %v", err))
 	}
 
 	wrappedProduct := struct {
@@ -231,12 +192,8 @@ func (fe *frontendServer) productHandler(w http.ResponseWriter, r *http.Request)
 		Price *pb.Money
 	}{product, price}
 
-	getCartCtx, getCartSpan := tracer.Start(ctx, "GetCart")
-	cart, err := fe.getCart(getCartCtx, sessionID(r))
-	getCartSpan.End()
+	cart, err := fe.getCart(ctx, sessionID(r))
 	if err != nil {
-		span.SetStatus(codes.Error, fmt.Sprintf("could not retrieve cart: %v", err))
-		span.RecordError(err)
 		renderHTTPError(log, r, w, errors.New("could not retrieve cart"), http.StatusInternalServerError)
 		return
 	}
@@ -257,8 +214,6 @@ func (fe *frontendServer) productHandler(w http.ResponseWriter, r *http.Request)
 // setCurrencyHandler 实现用户手动选择货币种类。请求路径：/setCurrency POST. 详见 header.html: 73
 func (fe *frontendServer) setCurrencyHandler(w http.ResponseWriter, r *http.Request) {
 	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
-	_, span := tracer.Start(r.Context(), "setCurrencyHandler")
-	defer span.End()
 
 	cur := r.FormValue("currency_code")                    // 自动从请求中提取名为 currency_code 的参数，无需关心请求方式是POST还是GET
 	payload := validator.SetCurrencyPayload{Currency: cur} // 构造一个 SetCurrencyPayload 对象，包含用户选择的货币代码
@@ -266,8 +221,6 @@ func (fe *frontendServer) setCurrencyHandler(w http.ResponseWriter, r *http.Requ
 	if err := payload.Validate(); err != nil {
 		log.Infof("Invalid currency code %q: %v", cur, err)
 		renderHTTPError(log, r, w, fmt.Errorf("invalid currency code %q", cur), http.StatusBadRequest)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		return
 	}
 
@@ -291,47 +244,30 @@ func (fe *frontendServer) setCurrencyHandler(w http.ResponseWriter, r *http.Requ
 // viewCartHandler 适用于 /cart GET HEAD请求
 func (fe *frontendServer) viewCartHandler(w http.ResponseWriter, r *http.Request) {
 	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
-	ctx, span := tracer.Start(r.Context(), "viewCartHandler")
-	defer span.End()
+	ctx := r.Context()
 
 	log.Debug("view cart")
 
-	getCurrenciesCtx, getCurrenciesSpan := tracer.Start(ctx, "GetCurrencies")
-	currencies, err := fe.getCurrencies(getCurrenciesCtx)
-	getCurrenciesSpan.End()
+	currencies, err := fe.getCurrencies(ctx)
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		renderHTTPError(log, r, w, fmt.Errorf("could not retrieve currencies: %v", err), http.StatusInternalServerError)
 		return
 	}
 
-	getCartCtx, getCartSpan := tracer.Start(ctx, "GetCart")
-	cartItems, err := fe.getCart(getCartCtx, sessionID(r))
-	getCartSpan.End()
+	cartItems, err := fe.getCart(ctx, sessionID(r))
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		renderHTTPError(log, r, w, fmt.Errorf("could not retrieve cart items: %v", err), http.StatusInternalServerError)
 		return
 	}
 
-	getRecommendationsCtx, getRecommendationsSpan := tracer.Start(ctx, "GetRecommendations")
-	recommendations, err := fe.getRecommendations(getRecommendationsCtx, sessionID(r), cartIDs(cartItems))
-	getRecommendationsSpan.End()
+	recommendations, err := fe.getRecommendations(ctx, sessionID(r), cartIDs(cartItems))
 	if err != nil {
 		// 获取推荐失败不应该影响用户查看购物车的体验，所以这里记录日志但不返回错误给用户
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		log.WithField("error", err).Warn("failed to get product recommendations")
 	}
 
-	getSippingQuoteCtx, getShippingQuoteSpan := tracer.Start(ctx, "GetShippingQuote")
-	shippingCost, err := fe.getShippingQuote(getSippingQuoteCtx, cartItems, currentCurrency(r))
-	getShippingQuoteSpan.End()
+	shippingCost, err := fe.getShippingQuote(ctx, cartItems, currentCurrency(r))
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		renderHTTPError(log, r, w, fmt.Errorf("could not retrieve shipping quote: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -346,25 +282,15 @@ func (fe *frontendServer) viewCartHandler(w http.ResponseWriter, r *http.Request
 	totalPrice := &pb.Money{CurrencyCode: currentCurrency(r)} // 购物车中所有产品的总价
 
 	for i, cartItem := range cartItems {
-		productCtx, productSpan := tracer.Start(ctx, "GetProduct")
-		p, err := fe.GetProduct(productCtx, cartItem.GetProductId())
-		productSpan.End()
+		p, err := fe.GetProduct(ctx, cartItem.GetProductId())
 		if err != nil {
 			renderHTTPError(log, r, w, fmt.Errorf("could not get product info: %v", err), http.StatusInternalServerError)
-			productSpan.SetStatus(codes.Error, fmt.Sprintf("could not get product info: %v", err))
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "failed to complete the order")
 			return
 		}
 
-		convertCurrencyCtx, convertCurrencySpan := tracer.Start(ctx, "ConvertCurrency")
-		price, err := fe.convertCurrency(convertCurrencyCtx, p.GetPriceUsd(), currentCurrency(r))
-		convertCurrencySpan.End()
+		price, err := fe.convertCurrency(ctx, p.GetPriceUsd(), currentCurrency(r))
 		if err != nil {
 			renderHTTPError(log, r, w, fmt.Errorf("could not convert currency: %v", err), http.StatusInternalServerError)
-			convertCurrencySpan.SetStatus(codes.Error, fmt.Sprintf("could not convert currency: %v", err))
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "failed to complete the order")
 			return
 		}
 
@@ -398,8 +324,7 @@ func (fe *frontendServer) viewCartHandler(w http.ResponseWriter, r *http.Request
 // addToCartHandler 适用于 /cart POST 请求，处理用户添加商品到购物车的请求
 func (fe *frontendServer) addToCartHandler(w http.ResponseWriter, r *http.Request) {
 	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
-	ctx, span := tracer.Start(r.Context(), "addToCartHandler")
-	defer span.End()
+	ctx := r.Context()
 
 	productId := r.FormValue("product_id") // 从请求中提取 product_id 参数
 	quantity, _ := strconv.ParseUint(r.FormValue("quantity"), 10, 32)
@@ -411,31 +336,19 @@ func (fe *frontendServer) addToCartHandler(w http.ResponseWriter, r *http.Reques
 	if err := payload.Validate(); err != nil {
 		log.WithField("validation_error", err).Warn("add to cart validation failed")
 		renderTopValidationPopup(r, w, validator.ValidationErrorResponse(err), http.StatusUnprocessableEntity)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		return
 	}
 	log.WithField("product", payload.ProductID).WithField("quantity", payload.Quantity).Debug("adding to cart")
 
-	productCtx, productSpan := tracer.Start(ctx, "GetProduct")
-	p, err := fe.GetProduct(productCtx, payload.ProductID)
-	productSpan.End()
+	p, err := fe.GetProduct(ctx, payload.ProductID)
 	if err != nil {
 		renderHTTPError(log, r, w, fmt.Errorf("could not retrieve product: %v", err), http.StatusInternalServerError)
-		productSpan.SetStatus(codes.Error, fmt.Sprintf("could not retrieve product: %v", err))
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		return
 	}
 
-	insertCtx, insertSpan := tracer.Start(ctx, "InsertCart")
-	err = fe.insertCart(insertCtx, sessionID(r), p.GetId(), int32(quantity))
-	insertSpan.End()
+	err = fe.insertCart(ctx, sessionID(r), p.GetId(), int32(quantity))
 	if err != nil {
 		renderHTTPError(log, r, w, fmt.Errorf("could not insert cart item: %v", err), http.StatusInternalServerError)
-		insertSpan.SetStatus(codes.Error, fmt.Sprintf("could not insert cart item: %v", err))
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		return
 	}
 
@@ -448,15 +361,12 @@ func (fe *frontendServer) addToCartHandler(w http.ResponseWriter, r *http.Reques
 
 func (fe *frontendServer) emptyCartHandler(w http.ResponseWriter, r *http.Request) {
 	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
-	ctx, span := tracer.Start(r.Context(), "emptyCartHandler")
-	defer span.End()
+	ctx := r.Context()
 
 	log.Debug("empty cart")
 	err := fe.emptyCart(ctx, sessionID(r))
 	if err != nil {
 		renderHTTPError(log, r, w, fmt.Errorf("failed to empty cart: %v", err), http.StatusInternalServerError)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		return
 	}
 	http.Redirect(w, r, r.Header.Get("Referer"), http.StatusSeeOther)
@@ -597,12 +507,7 @@ func (fe *frontendServer) emptyCart(ctx context.Context, userID string) error {
 func (fe *frontendServer) placeOrderHandler(w http.ResponseWriter, r *http.Request) {
 	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
 	log.Debug("placing order")
-	ctx, span := tracer.Start(r.Context(), "placeOrderHandler")
-	defer span.End()
-	span.SetAttributes(
-		attribute.String("session.id", sessionID(r)),
-		attribute.String("user.currency", currentCurrency(r)),
-	)
+	ctx := r.Context()
 	// 解析表单数据
 	var (
 		email         = r.FormValue("email")
@@ -631,16 +536,13 @@ func (fe *frontendServer) placeOrderHandler(w http.ResponseWriter, r *http.Reque
 	}
 	// 验证表单数据，验证规则：
 	if err := payload.Validate(); err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "place order validation failed")
 		log.WithField("validation_error", err).Warn("place order validation failed")
 		renderTopValidationPopup(r, w, validator.ValidationErrorResponse(err), http.StatusUnprocessableEntity)
 		return
 	}
 
-	checkoutCtx, checkoutSpan := tracer.Start(ctx, "CheckoutPlaceOrder")
 	order, err := pb.NewCheckoutServiceClient(fe.checkoutSvcConn).PlaceOrder(
-		checkoutCtx, &pb.PlaceOrderRequest{
+		ctx, &pb.PlaceOrderRequest{
 			Email: payload.Email,
 			CreditCard: &pb.CreditCardInfo{
 				CreditCardNumber:          payload.CcNumber,
@@ -656,27 +558,14 @@ func (fe *frontendServer) placeOrderHandler(w http.ResponseWriter, r *http.Reque
 				ZipCode:       int32(payload.ZipCode),
 				Country:       payload.Country},
 		})
-	checkoutSpan.End()
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to complete the order")
 		renderHTTPError(log, r, w, fmt.Errorf("failed to complete the order: %v", err), http.StatusInternalServerError)
 		return
 	}
-	if order.GetOrder() != nil {
-		span.SetAttributes(
-			attribute.String("order.id", order.GetOrder().GetOrderId()),
-			attribute.Int("order.items_count", len(order.GetOrder().GetItems())),
-		)
-	}
 	log.WithField("order", order.GetOrder().GetOrderId()).Info("order placed")
 
-	recommendationCtx, recommendationSpan := tracer.Start(ctx, "GetRecommendations")
-	recommendations, recommendationErr := fe.getRecommendations(recommendationCtx, sessionID(r), nil)
-	recommendationSpan.End()
+	recommendations, recommendationErr := fe.getRecommendations(ctx, sessionID(r), nil)
 	if recommendationErr != nil {
-		span.RecordError(recommendationErr)
-		span.SetStatus(codes.Error, fmt.Sprintf("could not retrieve recommendations: %v", recommendationErr))
 		log.WithField("error", recommendationErr).Warn("could not retrieve recommendations")
 	}
 
@@ -686,21 +575,9 @@ func (fe *frontendServer) placeOrderHandler(w http.ResponseWriter, r *http.Reque
 		multPrice := money.MultiplySlow(v.GetCost(), uint32(v.GetItem().GetQuantity()))
 		totalPaid = money.Must(money.Sum(totalPaid, multPrice))
 	}
-	if totalPaid != nil {
-		span.SetAttributes(
-			attribute.String("order.total.currency", totalPaid.GetCurrencyCode()),
-			attribute.Int64("order.total.units", totalPaid.GetUnits()),
-			attribute.Int64("order.total.nanos", int64(totalPaid.GetNanos())),
-		)
-	}
-
 	// 获取可用货币列表
-	currencyCtx, currencySpan := tracer.Start(ctx, "GetCurrencies")
-	currencies, err := fe.getCurrencies(currencyCtx)
-	currencySpan.End()
+	currencies, err := fe.getCurrencies(ctx)
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "could not retrieve currencies")
 		renderHTTPError(log, r, w, fmt.Errorf("could not retrieve currencies: %v", err), http.StatusInternalServerError)
 		return
 	}

--- a/src/frontend/main.go
+++ b/src/frontend/main.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/gorilla/mux"
 	"github.com/kznLeaf/curated-store/infra/xgrpc"
@@ -64,7 +63,6 @@ const (
 
 var (
 	baseUrl = ""
-	tracer  trace.Tracer
 )
 
 func main() {
@@ -93,8 +91,6 @@ func main() {
 			}
 		}()
 	}
-
-	tracer = tp.Tracer("frontend-tracer")
 
 	srvPort := port
 	// PORT 环境变量定义在k8s清单文件中。


### PR DESCRIPTION
Remove manual instrumentation from frontend handlers, as OpenTelemetry tracing is automatically implemented when the gRPC connection is established. 

For client:

```go
func MustConnGRPC(ctx context.Context, conn **grpc.ClientConn, addr string) {
	var err error

	*conn, err = grpc.NewClient(addr,
		grpc.WithTransportCredentials(insecure.NewCredentials()),
		grpc.WithStatsHandler(otelgrpc.NewClientHandler())) //  instrument gRPC client connection
	if err != nil {
		logrus.Fatalf("failed to connect to gRPC service %q: %v", addr, err)
	}
}
```

For server:

```go
func main() {

        ...

	srv = grpc.NewServer(
		grpc.StatsHandler(otelgrpc.NewServerHandler())) // gRPC auto-instrumentation

        ...

	go func() {
		if err := srv.Serve(listener); err != nil {
			log.Error(fmt.Sprintf("Failed to serve gRPC server, err: %v", err))
		}
	}()
        ...
}
```

In this case, each operation is automatically named like `hipstershop/CheckoutService/PlaceOrder`.